### PR TITLE
Package Tracking: Updated Regex triggers for USPS packages

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -60,9 +60,10 @@ my %patterns_re = (
 
     ## USPS
     # Source: https://tools.usps.com/go/TrackConfirmAction!input.action
+    # Note: Amount of prefixes in use by USPS has expanded.
     usps => qr/^
         (?:
-            (94001|92055|94073|93033|92701|92088|92021)\d{17} |
+            9[1-5]\d{20} |
             82\d{8} |
             [A-Z]{2}\d{9}US
         )


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
The 5-digit prefixes currently in use do not fully encompass possible tracking numbers, the actual range is much wider due to large logistics companies being given their own prefixes. Most (if not all) of Amazon's USPS shipments feature new custom prefixes, but there is no public database (as far as I am aware).
(e.g. 9114901075742452019146, 92612999944107571299443958, 9274890223341803609529, 9300120111408701022466, 9361289675007799134617, 9374889706008693399886, 9505511664721352960342)

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
This has been debated in #3973 years ago, but I believe this small fix will expand the functionality of this IA greatly. As of right now, searching for USPS tracking numbers on DDG is not possible.

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@mailkov

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->
